### PR TITLE
feat(infra): dev-stand (pg, redis, minio, mailhog, traefik; dash=8090)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# БД/кэш/хранилище
+DATABASE_URL=postgresql://layba:layba@127.0.0.1:5432/layba
+REDIS_URL=redis://127.0.0.1:6379/0
+MINIO_ENDPOINT=http://127.0.0.1:9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+MINIO_BUCKET=layba-dev
+MINIO_REGION=eu-central-1
+
+# Почта (dev -> Mailhog)
+EMAIL_HOST=127.0.0.1
+EMAIL_PORT=1025
+DEFAULT_FROM_EMAIL=no-reply@layba.net
+
+# Backend base
+DJANGO_SECRET_KEY=change-me
+DEBUG=true
+ALLOWED_HOSTS=backend.localhost,127.0.0.1
+
+# Обсервабилити (dev пусто)
+SENTRY_DSN=
+OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# Frontend/Mobile
+NEXT_PUBLIC_API_BASE_URL=http://backend.localhost
+API_BASE_URL_MOBILE=http://backend.localhost

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.egg-info/
+.venv/
+.env.example
+.env.*
+
+# Node
+node_modules/
+npm-debug.log*
+yarn.lock
+pnpm-lock.yaml
+
+# VSCode/JetBrains
+.vscode/
+.idea/
+
+# Build/Dist
+dist/
+build/
+coverage/
+
+# Docker
+*.pid
+*.log
+
+# Misc
+*.swp
+*.swo
+ .env
+# env files
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Auto Platform (monorepo)
+
+Чистый старт проекта: backend (Django/DRF), frontend (Next.js), mobile (Expo RN), shared/contracts (OpenAPI), infra (Docker).
+
+Открыть в PyCharm: File → Open → C:\Projects\autoplatform

--- a/infra/dev-down.ps1
+++ b/infra/dev-down.ps1
@@ -1,0 +1,1 @@
+docker compose -f "$PSScriptRoot/docker-compose.yml" down

--- a/infra/dev-logs.ps1
+++ b/infra/dev-logs.ps1
@@ -1,0 +1,1 @@
+docker compose -f "$PSScriptRoot/docker-compose.yml" logs -f

--- a/infra/dev-reset.ps1
+++ b/infra/dev-reset.ps1
@@ -1,0 +1,2 @@
+docker compose -f "$PSScriptRoot/docker-compose.yml" down -v
+docker volume prune -f

--- a/infra/dev-up.ps1
+++ b/infra/dev-up.ps1
@@ -1,0 +1,1 @@
+docker compose -f "$PSScriptRoot/docker-compose.yml" up -d

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,81 @@
+
+
+name: layba-dev
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${PGUSER:-layba}
+      POSTGRES_PASSWORD: ${PGPASSWORD:-layba}
+      POSTGRES_DB: ${PGDATABASE:-layba}
+    ports:
+      - "5432:5432"          # если занят — поменяешь на 5433 снаружи
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7.2-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no"]  # dev: без персистентности
+    ports:
+      - "6379:6379"
+
+  minio:
+    image: minio/minio:RELEASE.2024-06-13T22-53-53Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "9000:9000"          # S3 API
+      - "9001:9001"          # Console
+    volumes:
+      - minio-data:/data
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    restart: unless-stopped
+    ports:
+      - "8025:8025"          # UI http://localhost:8025
+
+  traefik:
+    image: traefik:v3.0
+    restart: unless-stopped
+    command:
+      - "--api.dashboard=true"
+      - "--api.insecure=true"            # dev only; доступен на 127.0.0.1:8080
+      - "--providers.file.filename=/etc/traefik/dynamic.yml"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "80:80"
+      - "127.0.0.1:8090:8080"
+    volumes:
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+    depends_on:
+      - postgres
+      - redis
+      - minio
+      - mailhog
+
+  # Плейсхолдеры (подключишь позже)
+  # backend:
+  #   image: your-backend-image
+  #   labels:
+  #     traefik.http.routers.backend.rule: Host(`backend.localhost`)
+  #     traefik.http.services.backend.loadbalancer.server.port: "8000"
+  # frontend:
+  #   image: your-frontend-image
+  #   labels:
+  #     traefik.http.routers.frontend.rule: Host(`frontend.localhost`)
+  #     traefik.http.services.frontend.loadbalancer.server.port: "3000"
+
+volumes:
+  pgdata:
+  minio-data:

--- a/infra/docs/infra-ports.md
+++ b/infra/docs/infra-ports.md
@@ -1,0 +1,7 @@
+5432  — Postgres (внешний)
+6379  — Redis
+9000  — MinIO S3 API
+9001  — MinIO Console
+8025  — Mailhog UI
+80    — Traefik (web)
+8090  — Traefik Dashboard (локально)

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -1,0 +1,19 @@
+http:
+  routers:
+    # Эти роуты начнут работать, когда появятся контейнеры backend/frontend (выше в compose)
+    backend:
+      rule: Host(`backend.localhost`)
+      service: backend
+    frontend:
+      rule: Host(`frontend.localhost`)
+      service: frontend
+
+  services:
+    backend:
+      loadBalancer:
+        servers:
+          - url: "http://backend:8000"      # порт приложения внутри контейнера
+    frontend:
+      loadBalancer:
+        servers:
+          - url: "http://frontend:3000"


### PR DESCRIPTION
**Что сделано**
- Добавлен dev-стенд Docker: Postgres 16, Redis 7.2, MinIO (S3), Mailhog, Traefik v3.
- Traefik dashboard на 127.0.0.1:8090 (80 → web).
- Персистентные тома: pgdata, minio-data; Redis/Mailhog — эфемерно.
- Скрипты PowerShell: dev-up/down/reset/logs.
- Карта портов в infra/docs/infra-ports.md.
- .env.example (только ключи/назначение).

**Почему**
- Реализация спецификации «Dev-стенд: сервисы/порты/тома/ENV» (Этап −1).

**Как проверять**
1) `./infra/dev-up.ps1`
2) Открыть: Traefik http://127.0.0.1:8090, Mailhog http://127.0.0.1:8025, MinIO http://127.0.0.1:9001
3) `docker ps` — все сервисы Up

**DoD**
- [x] Сервисы поднялись (pg/redis/minio/mailhog/traefik).
- [x] Traefik dash доступен на 8090.
- [x] Карта портов обновлена; политика конфликтов зафиксирована.
- [x] Скрипты dev-управления работают на Windows 10.
- [x] `.env.example` добавлен (без секретов).

**Артефакты**
- Скриншоты UI (Traefik/Mailhog/MinIO)
- Вывод `docker ps`

**Риски/откат**
- Конфликт портов → меняем только внешний порт и фиксируем в infra/docs/infra-ports.md.
- Полный откат: `./infra/dev-down.ps1` (или `dev-reset.ps1` — удалит тома).
